### PR TITLE
Fix snippets

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -43,6 +43,17 @@ along with MBXTools.  If not, see <http://www.gnu.org/licenses/>.
             {"key": "selector", "operator": "equal", "operand": "tag.reference.internal.xml.mbx"},
             {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
             {"key": "preceding_text", "operator": "regex_contains",
-                "operand": "<\\s*xref\\s+ref\\s*=\\s*", "match_all": true}],
-        "command": "mbx_ref_cite", "args": {"insert_char": "\""}}
+                "operand": "<\\s*xref\\s+ref\\s*=\\s*", "match_all": true}
+        ],
+        "command": "mbx_ref_cite", "args": {"insert_char": "\""}
+    },
+    {
+        "keys": ["ctrl+alt+."],
+        "context": [
+            {"key": "selector", "operator": "equal", "operand": "text.xml.mbx"},
+            {"key": "selector", "operator": "not_equal", "operand": "string"},
+            {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+        ],
+        "command": "complete_snippet_no_space", "args": {}
+    }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -37,12 +37,24 @@ along with MBXTools.  If not, see <http://www.gnu.org/licenses/>.
         ],
         "command": "mbx_ref_cite"
     },
-    {   "keys": ["\""],
+    {
+        "keys": ["\""],
         "context":  [
             {"key": "setting.disable_mbx_ref_auto_trigger", "operator": "not_equal", "operand": true},
             {"key": "selector", "operator": "equal", "operand": "tag.reference.internal.xml.mbx"},
             {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
             {"key": "preceding_text", "operator": "regex_contains",
-                "operand": "<\\s*xref\\s+ref\\s*=\\s*", "match_all": true}],
-        "command": "mbx_ref_cite", "args": {"insert_char": "\""}}
+                "operand": "<\\s*xref\\s+ref\\s*=\\s*", "match_all": true}
+        ],
+        "command": "mbx_ref_cite", "args": {"insert_char": "\""}
+    },
+    {
+        "keys": ["ctrl+alt+."],
+        "context": [
+            {"key": "selector", "operator": "equal", "operand": "text.xml.mbx"},
+            {"key": "selector", "operator": "not_equal", "operand": "string"},
+            {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+        ],
+        "command": "complete_snippet_no_space", "args": {}
+    }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -44,5 +44,15 @@ along with MBXTools.  If not, see <http://www.gnu.org/licenses/>.
             {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
             {"key": "preceding_text", "operator": "regex_contains",
                 "operand": "<\\s*xref\\s+ref\\s*=\\s*", "match_all": true}],
-        "command": "mbx_ref_cite", "args": {"insert_char": "\""}}
+        "command": "mbx_ref_cite", "args": {"insert_char": "\""}
+    },
+    {
+        "keys": ["ctrl+alt+."],
+        "context": [
+            {"key": "selector", "operator": "equal", "operand": "text.xml.mbx"},
+            {"key": "selector", "operator": "not_equal", "operand": "string"},
+            {"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+        ],
+        "command": "complete_snippet_no_space", "args": {}
+    }
 ]

--- a/TODO
+++ b/TODO
@@ -3,5 +3,6 @@ want to suggest a feature, open an issue at
 
     https://github.com/daverosoff/MBXTools
 
+* Fix snippets so they correctly handle <nonempty>tags</nonempty>
 * Text command to move to next subdiv/block lacking xml:id
 * adapt subdiv snippets for wrapping selection

--- a/complete_snippet_no_space.py
+++ b/complete_snippet_no_space.py
@@ -1,0 +1,62 @@
+import sublime
+import sublime_plugin
+import re
+
+
+if sublime.version() < '3000':
+    _ST3 = False
+else:
+    _ST3 = True
+
+# try:
+#     from .mbx_ref_completions import MbxToolsReplaceCommand
+# except ImportError:
+#     from mbx_ref_completions import MbxToolsReplaceCommand
+
+# class MbxToolsReplaceCommand(sublime_plugin.TextCommand):
+#     def run(self, edit, a, b, replacement):
+#         #print("DEBUG: types of a and b are " + repr(type(a)) + " and " + repr(type(b)))
+#         # On ST2, a and b are passed as long, but received as floats
+#         # It's probably a bug. Convert to be safe.
+#         if _ST3:
+#             region = sublime.Region(a, b)
+#         else:
+#             region = sublime.Region(long(a), long(b))
+#         self.view.replace(edit, region, replacement)
+
+class CompleteSnippetNoSpaceCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        triggermap = {
+            "amp": "<ampersand />",
+            "ell": "<ellipsis />",
+            "md": "<mdash />",
+            "nd": "<ndash />",
+            "pct": "<percent />"
+        }
+        print("YES!!")
+        view = self.view
+        sels = view.sel()
+        for s in sels:
+            point = s.b
+            word = view.word(s.b)
+            content = view.substr(word)
+            new_b = s.b
+            for k, v in triggermap.items():
+                if content.endswith(k):
+                    print("content:" + content)
+                    prefix = re.sub(k, '', content)
+                    print("prefix:" + prefix)
+                    new_a = new_b - len(k)
+                    # new_a = point
+                    region = sublime.Region(new_a, new_b)
+                    print("YES!")
+                    view.replace(edit, region, v)
+                    return
+
+    # def is_enabled(a, b):
+        # if _ST3:
+        #     region = sublime.Region(a, b)
+        # else:
+        #     region = sublime.Region(long(a), long(b))
+        # return True

--- a/messages.json
+++ b/messages.json
@@ -7,4 +7,5 @@
     "0.4.0": "messages/0.4.0.txt",
     "0.4.1": "messages/0.4.1.txt",
     "0.4.2": "messages/0.4.2.txt",
+    "0.4.3": "messages/0.4.3.txt",
 }

--- a/messages/0.4.3.txt
+++ b/messages/0.4.3.txt
@@ -1,4 +1,4 @@
-MBXTools package, public (pre-)release:
+MBXTools, package version 0.4.3
 
 Thank you for your interest in MBXTools. Make sure to inspect the README.md
 for instructions on usage and configuring your MathBook XML files to work
@@ -8,6 +8,14 @@ please open an issue at
     https://github.com/daverosoff/MBXTools
 
 I hope you find MBXTools useful!
+
+Release notes:
+
+    * Improved snippet triggers
+    * Snippets for <mdash />, <ndash />, <ellipsis />, <ampersand />,
+      and <percent /> are available via Ctrl+Alt+. at the end
+      of a word (so, the character preceding the trigger need not be
+      a space)
 
 Known issues:
 

--- a/messages/next.txt
+++ b/messages/next.txt
@@ -23,8 +23,8 @@ Known issues:
       completely satisfactory results (e.g., XML tags inside)
         - Should there be a user setting to disable this mirroring?
         - Is this even possible?
-    * MathBook XML syntax is inappropriately applied to newly opened
-      files of other types in some instances
+    * MathBook XML syntax is inappropriately applied to files of 
+      other types in some instances
     * Typing '<xref ref=""' results in a spurious error ("ref/cite: 
       unrecognized format")
     * Potential for confusion since Symbols List is always based on

--- a/snippets/ampersand.sublime-snippet
+++ b/snippets/ampersand.sublime-snippet
@@ -3,7 +3,7 @@
 <ampersand />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>ampersand</tabTrigger>
+    <tabTrigger>amp</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/dollar.sublime-snippet
+++ b/snippets/dollar.sublime-snippet
@@ -3,7 +3,7 @@
 <dollar />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>dollar</tabTrigger>
+    <tabTrigger>dol</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/ellipsis.sublime-snippet
+++ b/snippets/ellipsis.sublime-snippet
@@ -3,7 +3,7 @@
 <ellipsis />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>ellipsis</tabTrigger>
+    <tabTrigger>ell</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/greater.sublime-snippet
+++ b/snippets/greater.sublime-snippet
@@ -3,7 +3,7 @@
 <greater />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>greater</tabTrigger>
+    <tabTrigger>gt</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/less.sublime-snippet
+++ b/snippets/less.sublime-snippet
@@ -3,7 +3,7 @@
 <less />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>less</tabTrigger>
+    <tabTrigger>lt</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/mdash.sublime-snippet
+++ b/snippets/mdash.sublime-snippet
@@ -3,7 +3,7 @@
 <mdash />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>mdash</tabTrigger>
+    <tabTrigger>md</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/ndash.sublime-snippet
+++ b/snippets/ndash.sublime-snippet
@@ -3,7 +3,7 @@
 <ndash />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>ndash</tabTrigger>
+    <tabTrigger>nd</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>

--- a/snippets/percent.sublime-snippet
+++ b/snippets/percent.sublime-snippet
@@ -3,7 +3,7 @@
 <percent />$0
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>percent</tabTrigger>
+    <tabTrigger>pct</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>text.xml.mbx</scope>
 </snippet>


### PR DESCRIPTION
Snippet triggers are shorter (and not recognized as words, typically) and some snippets can be completed with <kbd>Ctrl+Alt+.</kbd> even when text precedes the trigger, e.g.

```
This examplemd
```

completes into

```
This example<mdash />
```

which is not possible with ordinary snippets because the trigger must be the whole word.
