### PR TITLE
Fix broken snippets

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -8,5 +8,6 @@
     "0.4.1": "messages/0.4.1.txt",
     "0.4.2": "messages/0.4.2.txt",
     "0.4.3": "messages/0.4.3.txt",
-    "0.4.4": "messages/0.4.4.txt"
+    "0.4.4": "messages/0.4.4.txt",
+    "0.4.5": "messages/0.4.5.txt"
 }

--- a/messages/0.4.5.txt
+++ b/messages/0.4.5.txt
@@ -1,0 +1,29 @@
+MBXTools, package version 0.4.5
+
+Thank you for your interest in MBXTools. Make sure to inspect the README.md
+for instructions on usage and configuring your MathBook XML files to work
+automatically with MBXTools. If you find a bug or have a feature request,
+please open an issue at
+
+    https://github.com/daverosoff/MBXTools
+
+I hope you find MBXTools useful!
+
+Release notes:
+
+    * Fixed broken theorem-like snippets
+
+Known issues:
+
+    * Mirrored title text in snippet xml:id does not always give
+      completely satisfactory results (e.g., XML tags inside)
+        - Should there be a user setting to disable this mirroring?
+        - Is this even possible?
+    * MathBook XML syntax is inappropriately applied to files of
+      other types in some instances
+    * Typing '<xref ref=""' results in a spurious error ("ref/cite:
+      unrecognized format")
+    * Potential for confusion since Symbols List is always based on
+      the current project (or open folder) but the ref autocomplete
+      list may not be (if there is not an explicit project and the
+      root MBX file is set globally or not at all)

--- a/messages/0.4.5.txt
+++ b/messages/0.4.5.txt
@@ -11,7 +11,7 @@ I hope you find MBXTools useful!
 
 Release notes:
 
-    * Fixed broken theorem-like snippets
+    * Fixed broken snippets (either not mirroring or totally nonfunctional)
 
 Known issues:
 

--- a/snippets/axiom-like/assumption.sublime-snippet
+++ b/snippets/axiom-like/assumption.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<assumption xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<assumption xml:id="assumption-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </assumption>$0

--- a/snippets/axiom-like/axiom.sublime-snippet
+++ b/snippets/axiom-like/axiom.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<axiom xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<axiom xml:id="axiom-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </axiom>$0

--- a/snippets/axiom-like/conjecture.sublime-snippet
+++ b/snippets/axiom-like/conjecture.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<conjecture xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<conjecture xml:id="conjecture-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </conjecture>$0

--- a/snippets/axiom-like/heuristic.sublime-snippet
+++ b/snippets/axiom-like/heuristic.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<heuristic xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<heuristic xml:id="heuristic-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </heuristic>$0

--- a/snippets/axiom-like/hypothesis.sublime-snippet
+++ b/snippets/axiom-like/hypothesis.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<hypothesis xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<hypothesis xml:id="hypothesis-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </hypothesis>$0

--- a/snippets/axiom-like/principle.sublime-snippet
+++ b/snippets/axiom-like/principle.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<principle xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<principle xml:id="principle-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </principle>$0

--- a/snippets/example-like/example.sublime-snippet
+++ b/snippets/example-like/example.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<example xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<example xml:id="example-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </example>$0
 ]]></content>

--- a/snippets/example-like/problem.sublime-snippet
+++ b/snippets/example-like/problem.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<problem xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<problem xml:id="problem-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </problem>$0
 ]]></content>

--- a/snippets/example-like/question.sublime-snippet
+++ b/snippets/example-like/question.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<question xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<question xml:id="question-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </question>$0
 ]]></content>

--- a/snippets/project-like/activity.sublime-snippet
+++ b/snippets/project-like/activity.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<activity xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<activity xml:id="activity-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </activity>$0
 ]]></content>

--- a/snippets/project-like/exploration.sublime-snippet
+++ b/snippets/project-like/exploration.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<exploration xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<exploration xml:id="exploration-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </exploration>$0
 ]]></content>

--- a/snippets/project-like/investigation.sublime-snippet
+++ b/snippets/project-like/investigation.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<investigation xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<investigation xml:id="investigation-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </investigation>$0
 ]]></content>

--- a/snippets/project-like/project.sublime-snippet
+++ b/snippets/project-like/project.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<project xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<project xml:id="project-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </project>$0
 ]]></content>

--- a/snippets/project-like/task.sublime-snippet
+++ b/snippets/project-like/task.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<task xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<task xml:id="task-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
 </task>$0
 ]]></content>

--- a/snippets/theorem-like/algorithm.sublime-snippet
+++ b/snippets/theorem-like/algorithm.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<algorithm xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<algorithm xml:id="algorithm-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </algorithm>$0

--- a/snippets/theorem-like/claim.sublime-snippet
+++ b/snippets/theorem-like/claim.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<claim xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<claim xml:id="claim-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </claim>$0

--- a/snippets/theorem-like/corollary.sublime-snippet
+++ b/snippets/theorem-like/corollary.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<corollary xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<corollary xml:id="${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </corollary>$0

--- a/snippets/theorem-like/corollary.sublime-snippet
+++ b/snippets/theorem-like/corollary.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<corollary xml:id="${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
+<corollary xml:id="corollary-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </corollary>$0

--- a/snippets/theorem-like/fact.sublime-snippet
+++ b/snippets/theorem-like/fact.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<fact xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<fact xml:id="fact-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </fact>$0

--- a/snippets/theorem-like/identity.sublime-snippet
+++ b/snippets/theorem-like/identity.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<identity xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<identity xml:id="identity-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </identity>$0

--- a/snippets/theorem-like/lemma.sublime-snippet
+++ b/snippets/theorem-like/lemma.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<lemma xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<lemma xml:id="lemma-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </lemma>$0

--- a/snippets/theorem-like/proposition.sublime-snippet
+++ b/snippets/theorem-like/proposition.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<proposition xml:id=\"${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)\">
+<proposition xml:id="proposition-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </proposition>$0

--- a/snippets/theorem-like/theorem.sublime-snippet
+++ b/snippets/theorem-like/theorem.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-<theorem xml:id="theorem-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/}">
+<theorem xml:id="theorem-${1/([A-Z])|(\s*<[^>]+>)|(\W+)/(?1\l$1:)(?2-:)(?3-:)/g}">
     <title>$1</title>
     <statement>$2</statement>
 </theorem>$0


### PR DESCRIPTION
Almost all theorem-like, axiom-like, etc. snippets had some missing Sublime magic used for mirroring title text in a valid `xml:id`. They work now.